### PR TITLE
Add preliminary support for instrumenting Express v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "Tushar Choudhari <tushar@last9.io> (https://github.com/chtushar)",
     "Aniket Rao <aniket@last9.io> (https://github.com/anik3tra0)"
   ],
-  "peerDependencies": {
-    "express": "4.x"
-  },
   "keywords": [
     "last9",
     "metrics",

--- a/src/clients/express.ts
+++ b/src/clients/express.ts
@@ -11,18 +11,16 @@ export const instrumentExpress = (
   redMiddleware: Express.RequestHandler,
   openapm: OpenAPM
 ) => {
-  let redMiddlewareAdded = false;
-
   const routerProto = express.Router as unknown as Express.Router['prototype'];
 
-  wrap(routerProto, 'use', (original) => {
+  wrap(routerProto.prototype, 'use', (original) => {
     return function wrappedUse(
       this: typeof original,
       ...args: Parameters<typeof original>
     ) {
-      if (!redMiddlewareAdded) {
+      if (!this._redMiddlewareAdded) {
         original.apply(this, [redMiddleware]);
-        redMiddlewareAdded = true;
+        this._redMiddlewareAdded = true;
       }
       return original.apply(this, args);
     };


### PR DESCRIPTION
Adds preliminary support for Express v5 by:
- Wrapping around express.Router.prototype instead of express.Router, since in v5 express.Router.use() doesn't exist;
- Sets the redMiddlewareAdded flag on a per router basis;